### PR TITLE
fix: use of separator '-' with v4

### DIFF
--- a/src/extractor/regex.js
+++ b/src/extractor/regex.js
@@ -53,7 +53,9 @@ export function zeroOrMore(source) {
  *
  * Based on https://stackoverflow.com/questions/17759004/how-to-match-string-within-parentheses-nested-in-java/17759264#17759264
  *
- * @param {string|RegExp|Array<string|RegExp>} source
+ * @param {string} open
+ * @param {string} close
+ * @param {number} depth
  */
 export function nestedBrackets(open, close, depth = 1) {
   return withoutCapturing([

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,6 @@ export class TailwindUtils {
     configPathOrContent: string | Record<PropertyKey, any>,
     options?: {
       pwd?: string
-      separator?: string
       prefix?: string
     },
   ): Promise<void> {
@@ -79,7 +78,7 @@ export class TailwindUtils {
 
     const extractorContext = {
       tailwindConfig: {
-        separator: options?.separator ?? '-',
+        separator: ':',
         prefix: options?.prefix ?? '',
       },
     }


### PR DESCRIPTION
### Description

Tailwindcss v4 uses the default non-configurable separator ':', not '-'.
Although v4 allows a js config file, it no longer allows the `separator` option.

Fix unrelated jsdoc issue (`nr lint`)

Ref: https://tailwindcss.com/docs/upgrade-guide#using-a-javascript-config-file
